### PR TITLE
[WIP] Fix #568: Update generator function

### DIFF
--- a/common/content/base.js
+++ b/common/content/base.js
@@ -16,25 +16,20 @@ function array(obj) {
     return util.Array(obj);
 }
 
-function allkeys(obj) {
+function* allkeys(obj) {
     for(; obj; obj = obj.__proto__)
         for (let prop of Object.getOwnPropertyNames(obj))
             yield prop;
 }
 
-function keys(obj) {
+function* keys(obj) {
     for (let prop of Object.getOwnPropertyNames(obj))
         yield prop;
 }
 
-function values(obj) {
-    for (var k of Object.keys(obj))
+function* values(obj) {
+    for (let k of Object.keys(obj))
         yield obj[k];
-}
-
-function foreach(iter, fn, self) {
-    for (let val in iter)
-        fn.call(self, val);
 }
 
 function dict(ary) {
@@ -227,7 +222,7 @@ function update(target, ...sources) {
         if (!src)
             continue;
 
-        foreach(keys(src), function (k) {
+        for (let k of keys(src)) {
             let desc = Object.getOwnPropertyDescriptor(src, k);
             Object.defineProperty(target, k, desc);
             if (("value" in desc) && callable(desc.value)) {
@@ -243,7 +238,7 @@ function update(target, ...sources) {
                 } else
                     v.superapply = v.supercall = function dummy() {};
             }
-        });
+        }
     }
     return target;
 }
@@ -457,8 +452,8 @@ const StructBase = Class("StructBase", {
 });
 // Add no-sideeffect array methods. Can't set new Array() as the prototype or
 // get length() won't work.
-for (let k in values(["concat", "every", "filter", "forEach", "indexOf", "join", "lastIndexOf",
-                      "map", "reduce", "reduceRight", "reverse", "slice", "some", "sort"]))
+for (let k of ["concat", "every", "filter", "forEach", "indexOf", "join", "lastIndexOf",
+               "map", "reduce", "reduceRight", "reverse", "slice", "some", "sort"])
     StructBase.prototype[k] = Array.prototype[k];
 
 // vim: set fdm=marker sw=4 ts=4 et:

--- a/common/content/bookmarks.js
+++ b/common/content/bookmarks.js
@@ -471,7 +471,7 @@ const Bookmarks = Module("bookmarks", {
         return node;
 
         function getFolderFromNode (node, title) {
-            for (let child in Bookmarks.iterateFolderChildren(node)) {
+            for (let child of Bookmarks.iterateFolderChildren(node)) {
                 if (child.title == title && child instanceof Ci.nsINavHistoryContainerResultNode) {
                     node.containerOpen = false;
                     return child;
@@ -480,7 +480,7 @@ const Bookmarks = Module("bookmarks", {
             return null;
         }
     },
-    iterateFolderChildren: function (node, onlyFolder, onlyWritable) {
+    iterateFolderChildren: function* (node, onlyFolder, onlyWritable) {
         if (!node.containerOpen)
             node.containerOpen = true;
 
@@ -809,7 +809,7 @@ const Bookmarks = Module("bookmarks", {
                 results.push(["TOOLBAR", "Bookmarks Toolbar"]);
             }
             if (folder) {
-                for (let child in Bookmarks.iterateFolderChildren(folder, onlyFolder, onlyWritable)) {
+                for (let child of Bookmarks.iterateFolderChildren(folder, onlyFolder, onlyWritable)) {
                     if (PlacesUtils.nodeIsSeparator(child))
                         continue;
 

--- a/common/content/buffer.js
+++ b/common/content/buffer.js
@@ -562,7 +562,7 @@ const Buffer = Module("buffer", {
         synonyms.unshift(rel);
 
         function followFrame(frame) {
-            function iter(elems) {
+            function* iter(elems) {
                 for (let i = 0; i < elems.length; i++)
                     for (let rel of synonyms)
                         if (elems[i].rel.toLowerCase() == rel || elems[i].rev.toLowerCase() == rel)
@@ -571,14 +571,14 @@ const Buffer = Module("buffer", {
 
             // <link>s have higher priority than normal <a> hrefs
             let elems = frame.document.getElementsByTagName("link");
-            for (let elem in iter(elems)) {
+            for (let elem of iter(elems)) {
                 liberator.open(elem.href);
                 return true;
             }
 
             // no links? ok, look for hrefs
             elems = frame.document.getElementsByTagName("a");
-            for (let elem in iter(elems)) {
+            for (let elem of iter(elems)) {
                 buffer.followLink(elem, liberator.CURRENT_TAB);
                 return true;
             }
@@ -1408,7 +1408,7 @@ const Buffer = Module("buffer", {
             };
         }
 
-        function generateTabs (tabs) {
+        function* generateTabs (tabs) {
             for (let i = 0, tab; tab = tabs[i]; i++) {
                 let indicator = getIndicator(tab) + (tab.pinned ? "@" : " "),
                     label = tab.label || UNTITLED_LABEL,
@@ -1425,7 +1425,7 @@ const Buffer = Module("buffer", {
                 yield item;
             }
         }
-        function generateGroupList (group, groupName) {
+        function* generateGroupList (group, groupName) {
             let hasName = !!groupName;
             for (let [i, tabItem] in Iterator(group.getChildren())) {
                 let index = (tabItem.tab._tPos + 1) + ": ",
@@ -1524,7 +1524,7 @@ const Buffer = Module("buffer", {
             "Repeat the last key event",
             function (count) {
                 if (mappings.repeat) {
-                    for (let i in util.interruptibleRange(0, Math.max(count, 1), 100))
+                    for (let i of util.interruptibleRange(0, Math.max(count, 1), 100))
                         mappings.repeat();
                 }
             },

--- a/common/content/commandline.js
+++ b/common/content/commandline.js
@@ -1842,7 +1842,7 @@ const ItemList = Class("ItemList", {
             nodes.message.style.display = context.message ? "block" : "none";
             nodes.waiting.style.display = waiting ? "block" : "none";
 
-            for (let [i, row] in Iterator(context.getRows(start, end, this._doc)))
+            for (let [i, row] of context.getRows(start, end, this._doc))
                 nodes[i] = row;
             for (let [i, row] in util.Array.iteritems(nodes)) {
                 if (!row)

--- a/common/content/commands.js
+++ b/common/content/commands.js
@@ -945,7 +945,7 @@ const Commands = Module("commands", {
             ["@:"], "Repeat the last Ex command",
             function (count) {
                 if (commands.repeat) {
-                    for (let i in util.interruptibleRange(0, Math.max(count, 1), 100))
+                    for (let i of util.interruptibleRange(0, Math.max(count, 1), 100))
                         liberator.execute(commands.repeat);
                 }
                 else

--- a/common/content/completion.js
+++ b/common/content/completion.js
@@ -495,7 +495,7 @@ const CompletionContext = Class("CompletionContext", {
         return util.map(util.range(start, end, step), function (i) items[i]);
     },
 
-    getRows: function getRows(start, end, doc) {
+    getRows: function* getRows(start, end, doc) {
         let self = this;
         let items = this.items;
         let cache = this.cache.rows;

--- a/common/content/events.js
+++ b/common/content/events.js
@@ -82,7 +82,7 @@ const Events = Module("events", {
                     for (let dir of dirs) {
                          liberator.log("Sourcing macros directory: " + dir.path);
 
-                        for (let file in dir.iterDirectory()) {
+                        for (let file of dir.iterDirectory()) {
                             if (file.exists() && !file.isDirectory() && file.isReadable() &&
                                 /^[\w_-]+(\.vimp)?$/i.test(file.leafName)) {
                                 let name = file.leafName.replace(/\.vimp$/i, "");
@@ -134,7 +134,7 @@ const Events = Module("events", {
 
     destroy: function () {
         liberator.log("Removing all event listeners");
-        for (let args in values(this.sessionListeners))
+        for (let args of values(this.sessionListeners))
             args[0].removeEventListener.apply(args[0], args.slice(1));
     },
 

--- a/common/content/hints.js
+++ b/common/content/hints.js
@@ -446,7 +446,7 @@ const Hints = Module("hints", {
                 continue;
 
         inner:
-            for (let i in (util.interruptibleRange(start, end + 1, 500))) {
+            for (let i of (util.interruptibleRange(start, end + 1, 500))) {
                 let hint = this._pageHints[i];
 
                 let valid = validHint(hint.text);

--- a/common/content/io.js
+++ b/common/content/io.js
@@ -69,7 +69,7 @@ const File = Class("File", {
     /**
      * Iterates over the objects in this directory.
      */
-    iterDirectory: function () {
+    iterDirectory: function* () {
         if (!this.isDirectory())
             throw Error("Not a directory");
         let entries = this.directoryEntries;

--- a/common/content/javascript.js
+++ b/common/content/javascript.js
@@ -32,14 +32,14 @@ const JavaScript = Module("javascript", {
         }
     },
 
-    iter: function iter(obj, toplevel) {
+    iter: function* iter(obj, toplevel) {
         toplevel = !!toplevel;
         let seen = {};
 
         try {
             let orig = obj;
 
-            function iterObj(obj, toplevel) {
+            function* iterObj(obj, toplevel) {
                 if (Cu.isXrayWrapper(obj)) {
                     if (toplevel) {
                         yield {get wrappedJSObject() 0};
@@ -62,7 +62,7 @@ const JavaScript = Module("javascript", {
                         yield o;
             }
 
-            for (let obj in iterObj(orig, toplevel)) {
+            for (let obj of iterObj(orig, toplevel)) {
                 try {
                     for (let k of Object.getOwnPropertyNames(obj)) {
                         let name = "|" + k;

--- a/common/content/liberator.js
+++ b/common/content/liberator.js
@@ -1639,7 +1639,7 @@ const Liberator = Module("liberator", {
                         let each, eachUnits, totalUnits;
                         let total = 0;
 
-                        for (let i in util.interruptibleRange(0, count, 500)) {
+                        for (let i of util.interruptibleRange(0, count, 500)) {
                             let now = Date.now();
                             method();
                             total += Date.now() - now;

--- a/common/content/marks.js
+++ b/common/content/marks.js
@@ -276,7 +276,7 @@ const Marks = Module("marks", {
 
                     // check for illegal ranges - only allow a-z A-Z
                     if (matches = args.match(/[a-zA-Z]-[a-zA-Z]/g)) {
-                        for (let match in values(matches)) {
+                        for (let match of values(matches)) {
                             liberator.assert(/[a-z]-[a-z]|[A-Z]-[A-Z]/.test(match) &&
                                     match[0] <= match[2],
                                     "Invalid argument: " + args.match(match + ".*")[0]);

--- a/common/content/options.js
+++ b/common/content/options.js
@@ -946,7 +946,7 @@ const Options = Module("options", {
                         commandline.input("Warning: Resetting all preferences may make " + config.hostApplication + " unusable. Continue (yes/[no]): ",
                             function (resp) {
                                 if (resp == "yes")
-                                    for (let pref in values(options.allPrefs()))
+                                    for (let pref of values(options.allPrefs()))
                                         options.resetPref(pref);
                             },
                             { promptHighlight: "WarningMsg" });

--- a/common/content/tabs.js
+++ b/common/content/tabs.js
@@ -49,10 +49,10 @@ const Tabs = Module("tabs", {
     },
 
     /**
-     * @property {Iterator(Object)} A genenerator that returns all browsers
+     * @return {Generator} A genenerator that returns all browsers
      *     in the current window.
      */
-    get browsers() {
+    browsers: function* () {
         let browsers = config.tabbrowser.browsers;
         for (let i = 0; i < browsers.length; i++)
             yield [i, browsers[i]];
@@ -130,7 +130,7 @@ const Tabs = Module("tabs", {
     //      : unused? Remove me.
     get: function () {
         let buffers = [];
-        for (let [i, browser] in this.browsers) {
+        for (let [i, browser] of this.browsers()) {
             let title = browser.contentTitle || "(Untitled)";
             let uri = browser.currentURI.spec;
             let number = i + 1;
@@ -147,7 +147,7 @@ const Tabs = Module("tabs", {
      */
     // FIXME: Only called once...necessary?
     getContentIndex: function (content) {
-        for (let [i, browser] in this.browsers) {
+        for (let [i, browser] of this.browsers()) {
             if (browser.contentWindow == content || browser.contentDocument == content)
                 return i;
         }
@@ -387,7 +387,7 @@ const Tabs = Module("tabs", {
      * Stops loading all tabs.
      */
     stopAll: function () {
-        for (let [, browser] in this.browsers)
+        for (let [, browser] of this.browsers())
             browser.stop();
     },
 
@@ -424,7 +424,7 @@ const Tabs = Module("tabs", {
         let lowerBuffer = buffer.toLowerCase();
         let first = tabs.index();
         let nbrowsers = config.tabbrowser.browsers.length;
-        for (let [i, ] in tabs.browsers) {
+        for (let [i, ] of tabs.browsers()) {
             let index = (i + first) % nbrowsers;
             let browser = config.tabbrowser.browsers[index];
             let tab = tabs.getTab(index);

--- a/common/content/util.js
+++ b/common/content/util.js
@@ -638,7 +638,7 @@ const Util = Module("util", {
      * @param {number} time The time in milliseconds between thread yields.
      * @returns {Iterator(Object)}
      */
-    interruptibleRange: function interruptibleRange(start, end, time) {
+    interruptibleRange: function* interruptibleRange(start, end, time) {
         let endTime = Date.now() + time;
         while (start < end) {
             if (Date.now() > endTime) {

--- a/muttator/content/mail.js
+++ b/muttator/content/mail.js
@@ -211,20 +211,20 @@ const Mail = Module("mail", {
      *           ...
      *         ]
      */
-    getAllFolderRowMap: function (includeServers, includeMsgFolders) {
+    getAllFolderRowMap: function* (includeServers, includeMsgFolders) {
         if (includeServers === undefined)
             includeServers = false;
         if (includeMsgFolders === undefined)
             includeMsgFolders = true;
 
-        function walkChildren(children, prefix) {
+        function* walkChildren(children, prefix) {
             for (let [, row] in Iterator(children)) {
                 let folder = row._folder;
                 let folderString = prefix + "/" +
                                    (row.useServerNameOnly ? folder.server.prettyName : folder.abbreviatedName);
                 yield [row, folderString];
                 if (row.children.length > 0)
-                    for (let child in walkChildren(row.children, folderString))
+                    for (let child of walkChildren(row.children, folderString))
                         yield child;
             }
         }
@@ -241,8 +241,7 @@ const Mail = Module("mail", {
                 yield [row, folderString];
 
             if (includeMsgFolders && row.children.length > 0)
-                for (let child in walkChildren(row.children, folderString))
-                    yield child;
+                yield* walkChildren(row.children, folderString);
         }
     },
 
@@ -254,7 +253,7 @@ const Mail = Module("mail", {
         else
             filter = filter.toLowerCase();
 
-        for (let [row, name] in this.getAllFolderRowMap(includeServers, includeMsgFolders)) {
+        for (let [row, name] of this.getAllFolderRowMap(includeServers, includeMsgFolders)) {
             let folder = row._folder;
             // XXX: row._folder.prettyName is needed ? -- teramako
             if (name.toLowerCase().indexOf(filter) >= 0)
@@ -270,7 +269,7 @@ const Mail = Module("mail", {
 
         filter = filter.toLowerCase();
 
-        for (let [row, name] in this.getAllFolderRowMap(includeServers, includeMsgFolders)) {
+        for (let [row, name] of this.getAllFolderRowMap(includeServers, includeMsgFolders)) {
             let folder = row._folder;
             // XXX: row._folder.prettyName is needed ? -- teramako
             if (name.toLowerCase() == filter)
@@ -288,7 +287,9 @@ const Mail = Module("mail", {
      */
     getFoldersWithFlag: function (flag) {
         if (flag) {
-            return [row._folder for ([row] in this.getAllFolderRowMap(true,true)) if (row._folder.flags & flag)]
+            return Array.from(this.getAllFolderRowMap(true, true), ([row]) => row)
+                        .filter(row => row._folder.flags & flag)
+                        .map(row => row._folder);
         }
         return [];
     },
@@ -699,8 +700,9 @@ const Mail = Module("mail", {
         completion.mailFolder = function mailFolder(context) {
             context.anchored = false;
             context.quote = false;
-            context.completions = [[row[1], "Unread: " + row[0]._folder.getNumUnread(false)]
-                                   for (row in mail.getAllFolderRowMap(true,true))];
+            context.completions = Array.from(
+                mail.getAllFolderRowMap(true, true),
+                row => [row[1], "Unread: " + row[0]._folder.getNumUnread(false)]);
         };
     },
     mappings: function () {
@@ -1179,7 +1181,12 @@ const Mail = Module("mail", {
                     services.get("smtpService").defaultServer = server;
                     return value;
                 },
-                completer: function (context) [[s.key, s.serverURI] for ([, s] in Iterator(mail.smtpServers))],
+                completer: function (context) {
+                    return Array.from((function* () {
+                        for (let [, s] in Iterator(mail.smtpServers))
+                            yield [s.key, s.serverURI];
+                    })());
+                },
                 validator: Option.validateCompleter
             });
 

--- a/vimperator/NEWS
+++ b/vimperator/NEWS
@@ -1,5 +1,6 @@
 201x-xx-xx:
     * add option 'newtaburl' to set default URL in new tabs
+    * fix loading the tabs module
 
 2016-10-05:
     * update and fix css related issues


### PR DESCRIPTION
# Replace legacy generator with ES2015 generator
~~This PR will make to solve upstream upstream #568.~~
**(2017-01-29 updated)** This PR will make to solve part of upstream #568 (Tab operations).

## Progress status
- [x] common/content/base.js (not update `iter()`)
- [x] common/content/bookmarks.js
- [x] common/content/buffer.js (not update callback of `addPageInfoSection()`)
- [x] common/content/completion.js
- [x] common/content/io.js
- [x] common/content/javascript.js
- ~~[x] common/content/options.js~~
- [x] common/content/tabs.js
- [x] common/content/util.js (not update `evaluateXPath()`, `range()`, `itervalues()` and `iteritems()`)
- [x] muttator/content/mail.js

## Abstract for changing
- Replace legacy generator function `function(...){yield ...;}` with ES2015 generator function `function*(...){yield ...;}`
- Replace `for in` loop with `for of` loop in codes using above functions.

### Why does not update generator function *XXX*?
*XXX* has been used by other legacy iterators,  and the legacy iterator is not compatible with ES2015 generator functions (especially `for in` loop will not work). Therefore, there are necessary to update that legacy iterators that uses ES2015 generator, but the legacy iterator has been used anywhere, so changing all iterators takes too much time.